### PR TITLE
fix sessions limit reached

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(name):
 
 setup(
     name="wallbox",
-    version="0.5.1",
+    version="0.6.0",
     description="Module for interacting with Wallbox EV charger api",
     long_description=read("README.md"),
     long_description_content_type="text/markdown",

--- a/wallbox/bearerauth.py
+++ b/wallbox/bearerauth.py
@@ -1,0 +1,11 @@
+import requests
+from requests.auth import AuthBase
+
+
+class BearerAuth(AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers["authorization"] = "Bearer " + self.token
+        return r


### PR DESCRIPTION
Note
Currently, Home assistant users are having trouble with there mobile devices, because this plugin logs them again every 15minutes (ttl of the token). And, when reaching the sessions limit, previous sessions are deleted, meaning that mobile devices will have to login again. So, refresh-token login has been added in order to avoid every-15min-login, thus making sessions life much longer. Additionally, meaningful user-agent has been added.